### PR TITLE
add option to preserve line-height

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There are also additional attributes which can be used.
 
 Specifying a value for data-fittext allows you to fine tune the text size. The default is 1. Increasing this number (ie 1.5) will resize the text more aggressively. Decreasing this number (ie 0.5) will reduce the aggressiveness of resize. data-fittext-min and data-fittext-max allow you to set upper and lower limits.
 
-    <h1 data-fittext=".315" data-fittext-min="12" data-fittext-max="50">ng-FitText</h1>
+    <h1 data-fittext=".315" data-fittext-min="12" data-fittext-max="50" data-fittext-preserve-line-height="true">ng-FitText</h1>
 
 The element needs to either be a block element or an inline-block element with a width specified (% or px).
 

--- a/ng-FitText.js
+++ b/ng-FitText.js
@@ -21,7 +21,7 @@ angular.module( 'ngFitText', [] )
     'max': undefined
   })
 
-  .directive( 'fittext', [ 'config', 'fitTextConfig', function( config, fitTextConfig ) {
+  .directive( 'fittext', [ '$window', 'config', 'fitTextConfig', function( $window, config, fitTextConfig ) {
     return {
       restrict: 'A',
       scope: true,
@@ -29,10 +29,18 @@ angular.module( 'ngFitText', [] )
       replace: true,
       template: function( element, attrs ) {
         var tag = element[0].nodeName;
-        return "<" + tag + " data-ng-transclude data-ng-style='{fontSize:fontSize}'></" + tag + ">";
+        return "<" + tag + " data-ng-transclude data-ng-style='{lineHeight: lineHeight, fontSize:fontSize, verticalAlign: vAlign}'></" + tag + ">";
       },
       link: function( scope, element, attrs ) {
         angular.extend( config, fitTextConfig.config );
+
+        var lineHeight;
+
+        if(attrs.fittextPreserveLineHeight && $window.getComputedStyle) {
+          scope.lineHeight = $window.getComputedStyle(element[0])['line-height'];
+          scope.vAlign = $window.getComputedStyle(element[0])['vertical-align'];
+        }
+
 
         scope.compressor = attrs.fittext || 1;
         scope.minFontSize = attrs.fittextMin || config.min || Number.NEGATIVE_INFINITY;


### PR DESCRIPTION
This adds an option to preserve the line-height of the element. This is especially useful if you have boxes that all use the directive for a header and you want the text to be inline.
