### PR TITLE
Use jquery width() instead of offsetWidth

### DIFF
--- a/ng-FitText.js
+++ b/ng-FitText.js
@@ -37,10 +37,10 @@ angular.module( 'ngFitText', [] )
         scope.compressor = attrs.fittext || 1;
         scope.minFontSize = attrs.fittextMin || config.min || Number.NEGATIVE_INFINITY;
         scope.maxFontSize = attrs.fittextMax || config.max || Number.POSITIVE_INFINITY;
-        scope.elementWidth = element[0].offsetWidth;
+        scope.elementWidth = element.width();
 
         ( scope.resizer = function() {
-          scope.elementWidth = element[0].offsetWidth;
+          scope.elementWidth = element.width();
           scope.fontSize = Math.max(
             Math.min(
               scope.elementWidth / ( scope.compressor * 10 ),


### PR DESCRIPTION
Within an AngularJS environment there's no worry that we can't use the width() function, because even if JQuery is not used, it got jqLite.
The advantage in using width() over offsetWidth is that it excludes the horizontal padding in elements with CSS box-sizing: border-box, as it should, because the padding takes away from the actual width available for the text.
