### PR TITLE
Remove beginning slash in main

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ngFitText",
   "version": "3.1.0",
   "main": [
-    "/src/ng-FitText.js"
+    "src/ng-FitText.js"
   ],
   "keywords": [
     "angular",


### PR DESCRIPTION
I'm using wiredep (https://github.com/taptapship/wiredep) and noticed the package wasn't being picked up. The beginning slash is incorrect and should be removed.
For now, I'm overriding the package in my bower.json.